### PR TITLE
Docker Running Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+images/*.jpg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM tensorflow/tensorflow
+
+RUN mkdir /app
+WORKDIR /app
+COPY . /app
+RUN curl https://storage.googleapis.com/download.tensorflow.org/models/inception5h.zip -o inception5h.zip
+RUN unzip -u inception5h.zip
+
+CMD ["python", "deepdream.py", \
+    "--input", "dir/input.jpg", \
+    "--output", "dir/output.jpg", \
+    "--layer", "import/mixed5a_5x5_pre_relu", \
+    "--frames", "7", \
+    "--octaves", "10", \
+    "--iterations", "10"\
+]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,36 @@ python deepdream.py --input mystart.jpg --output output.jpg --layer import/mixed
 
 For help & options:
  python deepdream.py --help
+
+
+## Using Docker
+
+You don't need to install and manage python deps on your native system, just run the whole thing in a container!
+
+1. Install Docker for [Mac](https://www.docker.com/docker-mac) / [Linux](https://docs.docker.com/install/) / [Windows 10](https://docs.docker.com/docker-for-windows/install/#download-docker-for-windows)
+2. Start docker
+
+### Option 1: Get source and build it
+3. Clone project
+4. Build Docker image
+```bash
+docker build -t deepdream .
+```
+5. Place image in the `images` directory (in below examples, we create `images/input.jpg`)
+6. Run app in Docker
+```bash
+# deepdream
+docker run --rm -i -v $(pwd)/images:/app/images -t deepdream python deepdream.py --input images/input.jpg --output images/output.jpg --layer import/mixed5a_5x5_pre_relu --frames 7 --octaves 10 --iterations 10
+
+# zoom-in series
+docker run --rm -i -v $(pwd)/images:/app/images -t deepdream python deepdream.py --input images/input.jpg --output images/output.jpg --layer import/mixed4d_3x3 --frames 100 --frame_scale 1.4 --frame_crop --octaves 4  --iterations  10
+```
+
+## Option 2: Run from prebuilt image
+https://hub.docker.com/r/atomantic/deepdream/
+
+same as option 1, but reference `-t atomantic/deepdream` and run:
+```bash
+# deepdream
+docker run --rm -i -v $(pwd)/images:/app/images -t atomantic/deepdream python deepdream.py --input images/input.jpg --output images/output.jpg --layer import/mixed5a_5x5_pre_relu --frames 7 --octaves 10 --iterations 10
+```

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,1 @@
+place your images in here for mounting into a docker image (or as your run target)


### PR DESCRIPTION
Just a PR for reference, but feel free to pull it as is.

Docker allows me to skip having to manage multiple versions of python and libs on my machine.
I also pushed a built docker image to docker hub, so now you can run this without having to setup anything.

if you have `images/input.jpg` in the current dir, you can just run:
```
docker run --rm -v $(pwd)/images:/app/images atomantic/deepdream python deepdream.py --input images/input.jpg --output images/output.jpg --layer import/mixed5a_5x5_pre_relu --frames 7 --octaves 10 --iterations 10
```
and when the container dies, all of the output is in the `images` dir :)

You can also just run with the default command in the dockerfile, which produces the same as above:
```
docker run --rm -v $(pwd)/images:/app/images atomantic/deepdream
```